### PR TITLE
add vsn to app file

### DIFF
--- a/src/sumo_db_mysql.app.src
+++ b/src/sumo_db_mysql.app.src
@@ -1,5 +1,6 @@
 {application, sumo_db_mysql, [
   {description, "SumoDB MySQL Adapter"},
+  {vsn, "0.0.1"},
   {id, "sumo_db_mysql"},
   {registered, []},
   {applications, [


### PR DESCRIPTION
rebar3 seems to require that the `vsn` attribute is specified in the app file before it will compile sumo_db_mysql as a dependency:

``` bash
$ rebar3 compile
===> Verifying dependencies...
...
===> Compiling sumo_db_mysql
===> Failed to get app value 'vsn' from '/Users/jordan/development/kiosk_sync/_build/default/lib/sumo_db_mysql/src/sumo_db_mysql.app.src'

$ echo $?
1
```
